### PR TITLE
rectify the correct eval output dir

### DIFF
--- a/main/eval.py
+++ b/main/eval.py
@@ -69,7 +69,7 @@ def eval_model():
         iou /= num_imgs
         print('Overall IOU = %.4f' % iou)
         
-    with open(osp.join(cfg.output_eval_dir, '%s.txt'%cfg.animal_class) ,'w') as f:
+    with open(osp.join(cfg.eval_dir, '%s.txt'%cfg.animal_class) ,'w') as f:
         f.write('PCK = %.4f\n' % pck)
         if cfg.animal_class in ['horse', 'cow', 'sheep']:
             f.write('Overall IOU = %.4f\n' % iou)


### PR DESCRIPTION
There is a problem with the original eval output directory, we should change cfg.output_eval_dir to cfg.eval_dir.
Here are the test results:
<<cfg.output_eval_dir>>
![image](https://github.com/user-attachments/assets/050424c3-d7c8-4fe6-87a2-c92d95038e5c)
<<cfg.eval_dir>>
![image](https://github.com/user-attachments/assets/c24144f8-96de-4c03-84db-4e4ba5c2503a)